### PR TITLE
top.js: Do not format query parameter manually

### DIFF
--- a/priv/www/js/top.js
+++ b/priv/www/js/top.js
@@ -8,14 +8,16 @@ dispatcher_add(function(sammy) {
             go_to('#/top/ets/' + nodes[0].name + "/20");
         });
     sammy.get('#/top/:node/:row_count', function() {
-            render({'top':   {path:    '/top/' + esc(this.params['node']) + "?row_count=" + this.params['row_count'],
-                              options: {sort: true}},
+            render({'top':   {path:    '/top/' + esc(this.params['node']),
+                              options: {sort: true,
+                                        row_count: this.params['row_count']}},
                     'nodes': '/nodes'},
                     'processes', '#/top');
         });
     sammy.get('#/top/ets/:node/:row_count', function() {
-            render({'top': {path:  '/top/ets/' + esc(this.params['node']) + "?row_count=" + this.params['row_count'],
-                                   options: {sort: true}},
+            render({'top': {path:    '/top/ets/' + esc(this.params['node']),
+                            options: {sort: true,
+                                      row_count: this.params['row_count']}},
                     'nodes': '/nodes'},
                     'ets_tables', '#/top/ets');
         });


### PR DESCRIPTION
Fill the options hash map instead: arbitrary options are used as query parameters in rabbitmq-management's `main.js`.

This fixes sorting in the management UI: it was broken because the formatted URL looked like:

```
/api/top/rabbit?row_count=20?sort=memory&sort_reverse=true
```

Fixes #10.
