### PR TITLE
Set bounded timeout for OTP workers

### DIFF
--- a/src/rabbit_top_sup.erl
+++ b/src/rabbit_top_sup.erl
@@ -29,6 +29,6 @@ start_link() ->
 init([]) ->
     Top = {rabbit_top_worker,
            {rabbit_top_worker, start_link, []},
-           permanent, ?MAX_WAIT, worker, [rabbit_top_worker]},
+           permanent, ?WORKER_WAIT, worker, [rabbit_top_worker]},
     {ok, {{one_for_one, 10, 10}, [Top]}}.
 


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#541
Replace `MAX_WAIT` with `WORKER_WAIT`
