### PR TITLE
Include not named tables on top overview

### DIFF
--- a/priv/www/js/tmpl/ets_tables.ejs
+++ b/priv/www/js/tmpl/ets_tables.ejs
@@ -29,6 +29,7 @@
     <th><%= fmt_sort_desc_by_default('Memory', 'memory') %></th>
     <th><%= fmt_sort_desc_by_default('Size', 'size') %></th>
     <th><%= fmt_sort_desc_by_default('Type', 'type') %></th>
+    <th><%= fmt_sort_desc_by_default('Named', 'named_table') %></th>
     <th>Protection</th>
     <th>Compressed</th>
   </tr>
@@ -44,6 +45,7 @@
     <td><%= fmt_bytes(table.memory * 1.0) %></td>
     <td><%= table.size %></td>
     <td><%= table.type %></td>
+    <td><%= table.named_table %></td>
     <td><%= table.protection %></td>
     <td><%= table.compressed %></td>
   </tr>

--- a/src/rabbit_top_wm_ets_tables.erl
+++ b/src/rabbit_top_wm_ets_tables.erl
@@ -55,9 +55,9 @@ ets_tables(Node, Sort, Order, RowCount) ->
     end.
 
 fmt(Info) ->
-    {owner, Pid} = lists:keyfind(owner, 1, Info),
-    %% OTP 21 introduced the 'id' element that contains a reference.
-    %% These cannot be serialised and must be removed from the proplist
-    Info1 = lists:keydelete(owner, 1,
-                            lists:keydelete(id, 1, Info)),
-    [{owner,  rabbit_top_util:fmt(Pid)} | Info1].
+    {owner, OPid} = lists:keyfind(owner, 1, Info),
+    {heir, HPid} = lists:keyfind(heir, 1, Info),
+    Info1 = lists:keydelete(owner, 1, Info),
+    Info2 = lists:keydelete(heir, 1, Info1),
+    [{owner,  rabbit_top_util:fmt(OPid)},
+     {heir, rabbit_top_util:fmt(HPid)} | Info2].

--- a/src/rabbit_top_wm_ets_tables.erl
+++ b/src/rabbit_top_wm_ets_tables.erl
@@ -57,7 +57,10 @@ ets_tables(Node, Sort, Order, RowCount) ->
 fmt(Info) ->
     {owner, OPid} = lists:keyfind(owner, 1, Info),
     {heir, HPid} = lists:keyfind(heir, 1, Info),
-    Info1 = lists:keydelete(owner, 1, Info),
+    %% OTP 21 introduced the 'id' element that contains a reference.
+    %% These cannot be serialised and must be removed from the proplist
+    Info1 = lists:keydelete(owner, 1,
+                            lists:keydelete(id, 1, Info)),
     Info2 = lists:keydelete(heir, 1, Info1),
     [{owner,  rabbit_top_util:fmt(OPid)},
      {heir, rabbit_top_util:fmt(HPid)} | Info2].

--- a/src/rabbit_top_worker.erl
+++ b/src/rabbit_top_worker.erl
@@ -122,13 +122,12 @@ ets_tables(_OldTables) ->
         end,
         ets:all()).
 
-table_info(Table) when not is_atom(Table) -> undefined;
-table_info(TableName) when is_atom(TableName) ->
+table_info(Table) ->
     Info = lists:map(fun
                         ({memory, MemWords}) -> {memory, bytes(MemWords)};
                         (Other) -> Other
                      end,
-                     ets:info(TableName)),
+                     ets:info(Table)),
     {owner, OwnerPid} = lists:keyfind(owner, 1, Info),
     case process_info(OwnerPid, registered_name) of
         []                           -> Info;


### PR DESCRIPTION
Debugging a high memory consumption issue where binary memory wasn't released in the quorum queue implementation, we could not found any ETS table belonging to the `ra` application with a large number of entries. `ra` creates some not named tables that don't show up in the `Top ETS Tables` view, and those are the culprits of the memory consumption. Although most ETS tables in `ra` are named tables, showing all of them is useful for debugging purposes.

Per discussion with @kjnilsson.